### PR TITLE
PathFinder return null when no areas

### DIFF
--- a/course-generator/Pathfinder.lua
+++ b/course-generator/Pathfinder.lua
@@ -496,6 +496,11 @@ function HeadlandPathfinder:findPath(fromNode, toNode, headlands, workWidth, don
 	local nodes = {}
 	local nHeadlandsToUse = math.max(1, dontUseInnermostHeadland and #headlands - 1 or #headlands)
 
+	-- if nothing to show, just return 'nil'
+	if not headlands[1] or nHeadlandsToUse < 1 then
+		return nil
+	end
+	
 	for i = 1, nHeadlandsToUse do
 		for j, node in ipairs(headlands[i]) do
 			local newNode = PointXY:copy(node)


### PR DESCRIPTION
findPath should return null if there is an error with the script, will prevent (#4665)
I also made sure that everywhere using the function would handle a 'nil' return.